### PR TITLE
patch(peepo): Sort friends embed by both servers and factions

### DIFF
--- a/services/peepo/src/domain/Embed/FriendsEmbed.ts
+++ b/services/peepo/src/domain/Embed/FriendsEmbed.ts
@@ -21,23 +21,23 @@ export class FriendsEmbed implements APIEmbed {
   }
 
   private _populateFields(friends: Player[]) {
-    for (const server of Object.values(servers)) {
-      const field = getCharactersByServer(friends, server)
-
-      if (field) this.fields.push(field)
+    for (const serverId of Object.keys(servers)) {
+      for (const factionId of Object.keys(factions)) {
+        const field = getCharactersByServer(friends, serverId, factionId)
+        if (field) this.fields.push(field)
+      }
     }
   }
 }
 
-function getCharactersByServer(players: Player[], server: string) {
-  players = players.filter((p) => servers[p.serverId] == server).sort((a, b) => a.name.localeCompare(b.factionId))
+function getCharactersByServer(players: Player[], serverId: string, factionId: string) {
+  const server = servers[serverId]
+  const faction = factions[factionId]
+  players = players.filter((p) => p.serverId == serverId && p.factionId == factionId)
   return players.length
     ? {
-        name: `${emojis[server.toLowerCase()]} ${server}`,
-        value: `${code(
-          players.map((player) => `${getFaction(factions[player.factionId])} ${player.outfitTag ? `[${player.outfitTag}] ` : ''}${player.name.padEnd(25)}`).join('\n'),
-          'css'
-        )}`,
+        name: `${emojis[server.toLowerCase()]} ${server} \u200b \u200b ${emojis[faction.toLowerCase()]} ${faction}`,
+        value: `${code(players.map((player) => `${player.outfitTag ? `[${player.outfitTag}] ` : ''}${player.name.padEnd(25)}`).join('\n'), 'css')}`,
       }
     : null
 }

--- a/services/peepo/src/domain/Embed/VerifyPlayerEmbed.ts
+++ b/services/peepo/src/domain/Embed/VerifyPlayerEmbed.ts
@@ -5,6 +5,6 @@ export class VerifyPlayerEmbed implements APIEmbed {
   description: string
 
   constructor(player: Player) {
-    this.description = '### Just one more step\n' + `Press "Verify" below and log in as **${player.name}**, so we know it's you.`
+    this.description = '## Just one more step\n' + `Press "Verify" below and log in as **${player.name}**, so we know it's you.`
   }
 }

--- a/services/peepo/src/infrastructure/SlashCommand/Friends.ts
+++ b/services/peepo/src/infrastructure/SlashCommand/Friends.ts
@@ -18,7 +18,6 @@ export class FriendsCommand {
     if (name) await validateVerification(name, user, interaction)
 
     interaction.deferReply({ ephemeral: true })
-
     const friends = await getAltWideFriends(user, name)
     await reply(interaction, { embeds: [friends], ephemeral: true })
     const friendsAllAlts = await getAltWideFriends(user, name, true)


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
### What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] New Feature
- [x] Enhancement
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
- [ ] Yes <!-- If yes, please describe the impact and migration path for existing applications -->
- [x] No

### Description
Friend embeds are now sorted by both servers and factions (Resolves #112)