### PR TITLE
fix(players): Deduplicate input ids when priming data

### DIFF
--- a/services/players/src/application/Command/PopulatePlayers.ts
+++ b/services/players/src/application/Command/PopulatePlayers.ts
@@ -17,9 +17,10 @@ export class PopulatePlayersHandler implements ICommandHandler<PopulatePlayers, 
     const { ids } = command
     const players = await this._queryBus.execute(new GetPlayers(ids))
     const unpopulated = ids.filter((id) => !players.find((player) => player.id === id))
-    logger.info(unpopulated, 'prime unknown players')
+    const deduped = unpopulated.filter((id, index) => unpopulated.indexOf(id) === index)
+    logger.info(deduped, 'prime unknown players')
 
-    for (const id of unpopulated) {
+    for (const id of deduped) {
       await this._commandBus.execute(new PopulatePlayer(id))
     }
   }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
### What kind of change does this PR introduce?
- [x] Bugfix
- [ ] New Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
- [ ] Yes <!-- If yes, please describe the impact and migration path for existing applications -->
- [x] No

### Description
Fixes a bug where we would prime the same player twice, leading to a race condition in the repository save (Resolves #116)