### PR TITLE
fix(census): Reset player online state when individual servers are down

### DIFF
--- a/libs/players/client/src/lib/PlayerClient.ts
+++ b/libs/players/client/src/lib/PlayerClient.ts
@@ -76,9 +76,10 @@ export class PlayerClient extends SubscriptionClient {
     }
   }
 
-  async resetOnlineState(): Promise<void> {
+  async resetOnlineState(serverId?: string): Promise<void> {
     try {
-      await this.http.post('/v1/players/online/reset')
+      const params = serverId ? { serverId } : undefined
+      await this.http.post('/v1/players/online/reset', undefined, { params })
     } catch (error) {
       this._logger.error(error)
       throw error

--- a/services/players/src/application/Command/ResetOnlineState.ts
+++ b/services/players/src/application/Command/ResetOnlineState.ts
@@ -2,14 +2,15 @@ import { CommandHandler, ICommandHandler } from '@nestjs/cqrs'
 import { PlayerRepository } from '../../infrastructure/TypeOrm/Repository/PlayerRepository'
 
 export class ResetOnlineState {
-  constructor() {}
+  constructor(readonly serverId?: string) {}
 }
 
 @CommandHandler(ResetOnlineState)
 export class ResetOnlineStateHandler implements ICommandHandler<ResetOnlineState, void> {
   constructor(private _repository: PlayerRepository) {}
 
-  async execute(): Promise<void> {
-    await this._repository.resetOnlineState()
+  async execute(command: ResetOnlineState): Promise<void> {
+    const { serverId } = command
+    await this._repository.resetOnlineState(serverId)
   }
 }

--- a/services/players/src/domain/Entity/PlayerEntity.ts
+++ b/services/players/src/domain/Entity/PlayerEntity.ts
@@ -5,6 +5,7 @@ import { Column, Entity, Index, PrimaryColumn } from 'typeorm'
 
 @Entity()
 @Subscribable()
+@Index(['isOnline', 'serverId'])
 export class PlayerEntity extends SubscribableEntity implements Player {
   @PrimaryColumn('text')
   readonly id: string
@@ -22,7 +23,6 @@ export class PlayerEntity extends SubscribableEntity implements Player {
   @Column('text', { nullable: true })
   readonly outfitTag: string
 
-  @Index()
   @Column('boolean', { nullable: true })
   readonly isOnline: boolean
 

--- a/services/players/src/infrastructure/Controller/PlayersController.ts
+++ b/services/players/src/infrastructure/Controller/PlayersController.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post } from '@nestjs/common'
+import { Body, Controller, Post, Query } from '@nestjs/common'
 import { CommandBus, QueryBus } from '@nestjs/cqrs'
 import { Player } from '@ps2gg/players/types'
 import { PopulatePlayers } from '../../application/Command/PopulatePlayers'
@@ -26,7 +26,7 @@ export class PlayersController {
   }
 
   @Post('/online/reset')
-  async resetOnline(): Promise<Player[]> {
-    return this._commandBus.execute(new ResetOnlineState())
+  async resetOnline(@Query('serverId') serverId?: string): Promise<Player[]> {
+    return this._commandBus.execute(new ResetOnlineState(serverId))
   }
 }

--- a/services/players/src/infrastructure/TypeOrm/Repository/PlayerRepository.ts
+++ b/services/players/src/infrastructure/TypeOrm/Repository/PlayerRepository.ts
@@ -53,9 +53,10 @@ export class PlayerRepository {
     return player
   }
 
-  async resetOnlineState(): Promise<any> {
-    const result = await this._repository.update({ isOnline: true }, { isOnline: false })
-    logTransaction('resetOnlineStatus', { isOnline: true }, { result })
+  async resetOnlineState(serverId?: string): Promise<any> {
+    const query = serverId ? { isOnline: true, serverId } : { isOnline: true }
+    const result = await this._repository.update(query, { isOnline: false })
+    logTransaction('resetOnlineStatus', query, { result })
     return result
   }
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
### What kind of change does this PR introduce?
- [x] Bugfix
- [ ] New Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
- [ ] Yes <!-- If yes, please describe the impact and migration path for existing applications -->
- [x] No

### Description
Resets players' online states when individual servers go down (Resolves #117)