### PR TITLE
perf(peepo): Use preprocessed alt matches in sesh command

### DIFF
--- a/services/peepo/src/application/Query/GetAltWideSesh.ts
+++ b/services/peepo/src/application/Query/GetAltWideSesh.ts
@@ -5,7 +5,7 @@ import { getFriends } from './GetFriends'
 import { getPlayer } from './GetPlayer'
 import { getSesh } from './GetSesh'
 
-export async function getAltWideSesh(user: User, name: string, includesFriendsAlts = false): Promise<SeshEmbed> {
+export async function getAltWideSesh(user: User, name: string): Promise<SeshEmbed> {
   let characterIds = user.characterIds?.length ? user.characterIds : []
 
   const player = name ? await getPlayer(name) : null
@@ -15,7 +15,7 @@ export async function getAltWideSesh(user: User, name: string, includesFriendsAl
   const { altIds } = await getAltIds(characterIds)
   const friendLookupIds = [...altIds, ...characterIds]
   const { friendIds } = await getFriends(friendLookupIds)
-  const { altIds: friendAltIds, relations } = includesFriendsAlts ? await getAltIds(friendIds) : { altIds: [], relations: [] }
+  const { altIds: friendAltIds, relations } = await getAltIds(friendIds)
   const onlineLookupIds = [...friendIds, ...friendAltIds]
   const friends = await getSesh(onlineLookupIds, relations, player)
   return friends

--- a/services/peepo/src/infrastructure/SlashCommand/Sesh.ts
+++ b/services/peepo/src/infrastructure/SlashCommand/Sesh.ts
@@ -18,12 +18,10 @@ export class SeshCommand {
     if (!name && !user.characterIds?.length) return { interactionContext: [], embeds: [new VerifyHintEmbed()], ephemeral: true }
     if (name) await validateVerification(name, user, interaction)
 
-    const friends = await getAltWideSesh(user, name)
-    await reply(interaction, { embeds: [friends] })
-    const friendsAllAlts = await getAltWideSesh(user, name, true)
+    const sesh = await getAltWideSesh(user, name)
     return {
       interactionContext: [],
-      embeds: [friendsAllAlts],
+      embeds: [sesh],
     }
   }
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
### What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] New Feature
- [x] Enhancement
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
- [ ] Yes <!-- If yes, please describe the impact and migration path for existing applications -->
- [x] No

### Description
Improves the performance of the /sesh command (Resolves #122)